### PR TITLE
Add `when`-step support to `DateContext`

### DIFF
--- a/src/Context/DateContext.php
+++ b/src/Context/DateContext.php
@@ -7,11 +7,13 @@ namespace Elbformat\SymfonyBehatBundle\Context;
 use Behat\Behat\Context\Context;
 use Behat\Hook\BeforeScenario;
 use Behat\Step\Given;
+use Behat\Step\When;
 use SlopeIt\ClockMock\ClockMock;
 
 /**
- * Use ClockMock (https://github.com/slope-it/clock-mock) with uopz to mock the current date.
- * ! Make sure the ext-uopz is installed and activated !
+ * Use [ClockMock](https://github.com/slope-it/clock-mock) with uopz to mock the current date.
+ *
+ * __Make sure the ext-uopz is installed and activated!__
  *
  * @author Hannes Giesenow <hannes.giesenow@elbformat.de>
  */
@@ -24,6 +26,7 @@ class DateContext implements Context
     }
 
     #[Given('the current date is :date')]
+    #[When('I set the date to :timestamp')]
     public function theCurrentDateIs(string $date): void
     {
         ClockMock::freeze(new \DateTime($date));


### PR DESCRIPTION
This PR adds support for `when` clauses to the `DateContext`, enabling time-travel during integration tests ;-)